### PR TITLE
Don't cache vendor directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ after_success: ./ci/deploy.sh
 
 cache:
   directories:
-  - vendor
   - $HOME/.composer/cache
 
 branches:


### PR DESCRIPTION
The same as for wp-cli
https://github.com/wp-cli/wp-cli/pull/4534