### PR TITLE
Use --profile instead of -p for behat compat with symfony/console 2.8.32

### DIFF
--- a/ci/test-package.sh
+++ b/ci/test-package.sh
@@ -42,7 +42,7 @@ for REPO in $REPOS; do
 
 	BEHAT_PROFILE=""
 	if [ "$REPO" != "wp-cli/wp-cli" ]; then
-		BEHAT_PROFILE=" -p=$REPO"
+		BEHAT_PROFILE=" --profile $REPO"
 	fi
 
 	set +e

--- a/ci/test-phar.sh
+++ b/ci/test-phar.sh
@@ -70,7 +70,7 @@ for RELEASE in $RELEASES; do
 
 		BEHAT_PROFILE=""
 		if [ "$REPO" != "wp-cli/wp-cli" ]; then
-			BEHAT_PROFILE=" -p=$REPO"
+			BEHAT_PROFILE=" --profile $REPO"
 		fi
 
 		set +e


### PR DESCRIPTION
Re https://github.com/wp-cli/automated-tests/pull/12 the issue with Behat throwing:
```
[Symfony\Component\Console\Exception\InvalidArgumentException]  
  Unsupported format "progress".
```
is caused by the recent update of `symfony/console` from 2.8.31 to 2.8.32, in particular this change https://github.com/symfony/console/commit/46270f1ca44f08ebc134ce120fd2c2baf5fd63de where it's doing something different with options with a single hyphen. Changing the `BEHAT_PROFILE` invocation from `-p=` to `--profile ` seems to get around it.

More generally the issue emphasises that we're still using Behat version 2, which hasn't been updated in over 2 years and is no longer maintained. Migrating to Behat version 3 might be something to consider, probably for WP-CLI version 2?

The build will still fail until a new `wp-cli/db-command` is released, due to https://github.com/wp-cli/db-command/pull/70.

Somewhat unrelatedly, it'd probably be reasonable to ditch the stable job, as it's never going to pass. Also it might be worth adding a `"dev-master"` `TEST_PHAR` job, where the phar is built from the latest "dev-master"s of all the bundled commands, so as to get early warning of issues.