### PR TITLE
Restructure tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,14 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env: WP_VERSION=latest TEST_PACKAGE=all
-    - php: 5.6
-      env: WP_VERSION=latest TEST_PHAR=nightly
+    - php: 7.0
+      env: WP_VERSION=latest TEST_PACKAGE=wp-cli/wp-cli
+    - php: 7.0
+      env: WP_VERSION=latest TEST_PACKAGE=commands
+    - php: 7.0
+      env: WP_VERSION=latest TEST_PACKAGE=wp-cli/wp-cli TEST_PHAR=nightly
+    - php: 7.0
+      env: WP_VERSION=latest TEST_PACKAGE=commands TEST_PHAR=nightly
 
 before_script:
   - ./ci/prepare.sh

--- a/ci/test-phar.sh
+++ b/ci/test-phar.sh
@@ -15,8 +15,29 @@ set -e
 FAILED_PACKAGES=""
 
 RELEASES=""
-REPOS="wp-cli/wp-cli
+REPOS=""
+
+if [ -z "$TEST_PACKAGE" ]; then
+	TEST_PACKAGE="all"
+fi
+
+if [ "$TEST_PACKAGE" == "none" ]; then
+	echo "Skipping feature tests completely."
+	exit 0
+fi
+
+if [ "$TEST_PACKAGE" == "all" ]; then
+	REPOS="wp-cli/wp-cli
 $(cat vendor/wp-cli/wp-cli/composer.json | grep -oE "wp-cli/([a-z\-]*)-command")"
+fi
+
+if [ "$TEST_PACKAGE" == "commands" ]; then
+	REPOS="$(cat vendor/wp-cli/wp-cli/composer.json | grep -oE "wp-cli/([a-z\-]*)-command")"
+fi
+
+if [ "$TEST_PACKAGE" != "all" -a "$TEST_PACKAGE" != "commands" ]; then
+	REPOS="$TEST_PACKAGE"
+fi
 
 if [ -z "$TEST_PHAR" -o "$TEST_PHAR" == "none" ]; then
 	echo "Skipping feature tests completely."


### PR DESCRIPTION
* Allows Phar tests to specify packages as well
* Splits up tests into separate framework and commands runs
* Runs tests with PHP 7.0

This will hopefully run everything fast enough so we don't hit the time-outs.