### PR TITLE
Add `dealerdirect/phpcodesniffer-composer-installer` to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,10 @@
     },
     "config": {
         "process-timeout": 7200,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Test failures are expected but they are not related to `dealerdirect/phpcodesniffer-composer-installer` composer plugin.