### PR TITLE
Do not test WP trunk on PHP 5.6

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -75,11 +75,6 @@ jobs:
             mysql: '8.0'
             use-phar: true
             test-package: 'wp-cli-bundle'
-          - php: '5.6'
-            wp: 'trunk'
-            mysql: '8.0'
-            use-phar: true
-            test-package: 'wp-cli-bundle'
           - php: '7.0'
             wp: 'trunk'
             mysql: '8.0'


### PR DESCRIPTION
This is because WP trunk now requires PHP 7.0.

There already is a test covering trunk + PHP 7.0

See https://github.com/wp-cli/wp-cli/issues/5810