### PR TITLE
Run tests against Windows & macOS

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -62,6 +62,10 @@ jobs:
         if: ${{ startsWith(inputs.os, 'windows') }}
         run: choco install sqlite ghostscript --yes
 
+      - name: Install dependencies (macOS)
+        if: ${{ startsWith(inputs.os, 'macos') }}
+        run: brew install ghostscript
+
       - name: Set up PHP environment
         if: steps.check_files.outputs.files_exists == 'true'
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -25,6 +25,10 @@ on:
         type: string
         required: false
         default: 'ubuntu-22.04'
+      mysql:
+        type: string
+        required: false
+        default: ''
 
 jobs:
   run-test:
@@ -91,13 +95,15 @@ jobs:
         if: ${{ inputs.dbtype != 'sqlite' }}
         uses: shogo82148/actions-setup-mysql@9c42ca180d5f1dd4dceb54c23c5eda0384f4d265 # v1
         with:
-          mysql-version: '8.0' # Standard MySQL version for these tests
+          mysql-version: ${{ inputs.mysql || '8.0' }}
           auto-start: true
           root-password: ${{ env.WP_CLI_TEST_DBROOTPASS }}
           user: ${{ env.WP_CLI_TEST_DBUSER}}
           password: ${{ env.WP_CLI_TEST_DBPASS}}
           my-cnf: |
             default_authentication_plugin=mysql_native_password
+            ${{ inputs.dbtype == 'mariadb' && '[client]' || '' }}
+            ${{ inputs.dbtype == 'mariadb' && 'disable-ssl-verify-server-cert' || '' }}
 
       - name: Prepare test database
         if: steps.check_files.outputs.files_exists == 'true' && inputs.dbtype != 'sqlite'

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -71,7 +71,7 @@ jobs:
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: '${{ inputs.php }}'
-          extensions: gd, imagick, mysql, zip, pdo_sqlite, exif
+          extensions: gd, imagick, mysql, zip, pdo_sqlite, exif, fileinfo
           coverage: none
           tools: composer
 

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -21,11 +21,15 @@ on:
       use-phar:
         type: boolean
         required: true
+      os:
+        type: string
+        required: false
+        default: 'ubuntu-22.04'
 
 jobs:
   run-test:
-    name: WP ${{ inputs.wp }} | PHP ${{ inputs.php }} | ${{ inputs.dbtype == 'sqlite' && 'SQLite' || inputs.dbtype == 'mysql' && 'MySQL' || 'MariaDB' }}${{ inputs.use-phar && ' (Phar)' || '' }}${{ inputs.object_cache == 'sqlite' && ' (Obj Cache)' || '' }}
-    runs-on: ubuntu-22.04
+    name: WP ${{ inputs.wp }} | PHP ${{ inputs.php }} | ${{ inputs.dbtype == 'sqlite' && 'SQLite' || inputs.dbtype == 'mysql' && 'MySQL' || 'MariaDB' }}${{ inputs.use-phar && ' (Phar)' || '' }}${{ inputs.object_cache == 'sqlite' && ' (Obj Cache)' || '' }}${{ startsWith( inputs.os, 'windows' ) && ' (Windows)' || '' }}${{ startsWith( inputs.os, 'macos' ) && ' (macOS)' || '' }}
+    runs-on: ${{ inputs.os || 'ubuntu-22.04' }}
     continue-on-error: ${{ inputs.dbtype == 'sqlite' || inputs.object_cache == 'sqlite' }}
 
     env:
@@ -45,10 +49,11 @@ jobs:
 
       - name: Check existence of composer.json & behat.yml files
         id: check_files
+        shell: bash
         run: echo "files_exists=$([ -f composer.json ] && [ -f behat.yml ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Install Ghostscript
-        if: steps.check_files.outputs.files_exists == 'true'
+        if: steps.check_files.outputs.files_exists == 'true' && (inputs.os == 'ubuntu-22.04' || inputs.os == '')
         run: |
           sudo apt-get update
           sudo apt-get install ghostscript -y
@@ -69,7 +74,7 @@ jobs:
           COMPOSER_ROOT_VERSION: dev-${{ github.event.repository.default_branch }}
 
       - name: Change ImageMagick policy to allow pdf->png conversion.
-        if: steps.check_files.outputs.files_exists == 'true'
+        if: steps.check_files.outputs.files_exists == 'true' && (inputs.os == 'ubuntu-22.04' || inputs.os == '')
         run: |
           sudo sed -i 's/^.*policy.*coder.*none.*PDF.*//' /etc/ImageMagick-6/policy.xml
 
@@ -92,6 +97,7 @@ jobs:
 
       - name: Conditionally use Phar instead of source
         if: steps.check_files.outputs.files_exists == 'true' && inputs.use-phar == true
+        shell: bash
         run: echo "TEST_PHAR=nightly" >> $GITHUB_ENV
 
       - name: Check Behat environment
@@ -100,7 +106,8 @@ jobs:
           WP_VERSION: '${{ inputs.wp }}'
           WP_CLI_TEST_DBTYPE: ${{ inputs.dbtype }}
           WP_CLI_TEST_DBSOCKET: '${{ steps.setup-mysql.outputs.base-dir }}/tmp/mysql.sock'
-        run: WP_CLI_TEST_DEBUG_BEHAT_ENV=1 composer behat
+          WP_CLI_TEST_DEBUG_BEHAT_ENV: 1
+        run: composer behat
 
       - name: Run Behat
         if: steps.check_files.outputs.files_exists == 'true'

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -105,6 +105,10 @@ jobs:
             ${{ inputs.dbtype == 'mariadb' && '[client]' || '' }}
             ${{ inputs.dbtype == 'mariadb' && 'disable-ssl-verify-server-cert' || '' }}
 
+      - name: Remove system MySQL binary
+        if: steps.check_files.outputs.files_exists == 'true' && inputs.dbtype != 'sqlite'
+        run: sudo rm -f /usr/bin/mysql /usr/bin/mysqldump
+
       - name: Prepare test database
         if: steps.check_files.outputs.files_exists == 'true' && inputs.dbtype != 'sqlite'
         run: composer prepare-tests

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -125,6 +125,7 @@ jobs:
           WP_CLI_TEST_DBTYPE: ${{ inputs.dbtype }}
           WP_CLI_TEST_DBSOCKET: '${{ steps.setup-mysql.outputs.base-dir }}/tmp/mysql.sock'
           WP_CLI_TEST_DEBUG_BEHAT_ENV: 1
+          SSL_CERT_FILE: '${{ steps.setup-mysql.outputs.base-dir }}/var/ca.pem'
         run: composer behat
 
       - name: Run Behat
@@ -134,4 +135,5 @@ jobs:
           WP_CLI_TEST_DBTYPE: ${{ inputs.dbtype }}
           TEST_PACKAGE: 'wp-cli/${{ inputs.test-package }}'
           WP_CLI_TEST_DBSOCKET: '${{ steps.setup-mysql.outputs.base-dir }}/tmp/mysql.sock'
+          SSL_CERT_FILE: '${{ steps.setup-mysql.outputs.base-dir }}/var/ca.pem'
         run: composer test

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -105,12 +105,6 @@ jobs:
             ${{ inputs.dbtype == 'mariadb' && '[client]' || '' }}
             ${{ inputs.dbtype == 'mariadb' && 'disable-ssl-verify-server-cert' || '' }}
 
-      - name: Trust GHA CA cert on Linux GHA
-        if: steps.check_files.outputs.files_exists == 'true' && inputs.dbtype == 'mariadb' && (inputs.os == 'ubuntu-22.04' || inputs.os == '')
-        run: |
-          sudo cp "${{ steps.setup-mysql.outputs.base-dir }}/var/ca.pem" /usr/local/share/ca-certificates/gha-ca.crt
-          sudo update-ca-certificates
-
       - name: Remove system MySQL binary
         if: steps.check_files.outputs.files_exists == 'true' && inputs.dbtype != 'sqlite'
         run: sudo rm -f /usr/bin/mysql /usr/bin/mysqldump
@@ -131,6 +125,8 @@ jobs:
           WP_CLI_TEST_DBTYPE: ${{ inputs.dbtype }}
           WP_CLI_TEST_DBSOCKET: '${{ steps.setup-mysql.outputs.base-dir }}/tmp/mysql.sock'
           WP_CLI_TEST_DEBUG_BEHAT_ENV: 1
+          SSL_CERT_FILE: '${{ steps.setup-mysql.outputs.base-dir }}/var/ca.pem'
+          CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
         run: composer behat
 
       - name: Run Behat
@@ -140,4 +136,6 @@ jobs:
           WP_CLI_TEST_DBTYPE: ${{ inputs.dbtype }}
           TEST_PACKAGE: 'wp-cli/${{ inputs.test-package }}'
           WP_CLI_TEST_DBSOCKET: '${{ steps.setup-mysql.outputs.base-dir }}/tmp/mysql.sock'
+          SSL_CERT_FILE: '${{ steps.setup-mysql.outputs.base-dir }}/var/ca.pem'
+          CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
         run: composer test

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -63,7 +63,7 @@ jobs:
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: '${{ inputs.php }}'
-          extensions: gd, imagick, mysql, zip, pdo_sqlite
+          extensions: gd, imagick, mysql, zip, pdo_sqlite, exif
           coverage: none
           tools: composer
 

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -58,6 +58,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install ghostscript -y
 
+      - name: Install dependencies (Windows)
+        if: ${{ startsWith(inputs.os, 'windows') }}
+        run: choco install sqlite ghostscript --yes
+
       - name: Set up PHP environment
         if: steps.check_files.outputs.files_exists == 'true'
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -107,7 +107,9 @@ jobs:
 
       - name: Trust GHA CA cert on Linux GHA
         if: steps.check_files.outputs.files_exists == 'true' && inputs.dbtype == 'mariadb' && (inputs.os == 'ubuntu-22.04' || inputs.os == '')
-        run: cat "${{ steps.setup-mysql.outputs.base-dir }}/var/ca.pem" | sudo tee -a /etc/ssl/certs/ca-certificates.crt
+        run: |
+          sudo cp "${{ steps.setup-mysql.outputs.base-dir }}/var/ca.pem" /usr/local/share/ca-certificates/gha-ca.crt
+          sudo update-ca-certificates
 
       - name: Remove system MySQL binary
         if: steps.check_files.outputs.files_exists == 'true' && inputs.dbtype != 'sqlite'

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -105,6 +105,10 @@ jobs:
             ${{ inputs.dbtype == 'mariadb' && '[client]' || '' }}
             ${{ inputs.dbtype == 'mariadb' && 'disable-ssl-verify-server-cert' || '' }}
 
+      - name: Trust GHA CA cert on Linux GHA
+        if: steps.check_files.outputs.files_exists == 'true' && inputs.dbtype == 'mariadb' && (inputs.os == 'ubuntu-22.04' || inputs.os == '')
+        run: cat "${{ steps.setup-mysql.outputs.base-dir }}/var/ca.pem" | sudo tee -a /etc/ssl/certs/ca-certificates.crt
+
       - name: Remove system MySQL binary
         if: steps.check_files.outputs.files_exists == 'true' && inputs.dbtype != 'sqlite'
         run: sudo rm -f /usr/bin/mysql /usr/bin/mysqldump
@@ -125,7 +129,6 @@ jobs:
           WP_CLI_TEST_DBTYPE: ${{ inputs.dbtype }}
           WP_CLI_TEST_DBSOCKET: '${{ steps.setup-mysql.outputs.base-dir }}/tmp/mysql.sock'
           WP_CLI_TEST_DEBUG_BEHAT_ENV: 1
-          SSL_CERT_FILE: '${{ steps.setup-mysql.outputs.base-dir }}/var/ca.pem'
         run: composer behat
 
       - name: Run Behat
@@ -135,5 +138,4 @@ jobs:
           WP_CLI_TEST_DBTYPE: ${{ inputs.dbtype }}
           TEST_PACKAGE: 'wp-cli/${{ inputs.test-package }}'
           WP_CLI_TEST_DBSOCKET: '${{ steps.setup-mysql.outputs.base-dir }}/tmp/mysql.sock'
-          SSL_CERT_FILE: '${{ steps.setup-mysql.outputs.base-dir }}/var/ca.pem'
         run: composer test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,6 +20,7 @@ jobs:
         php: ['7.2', '8.5']
         wp: ['latest', 'trunk']
         dbtype: ['mysql', 'sqlite', 'mariadb']
+        mysql: ['mysql-8.0']
         object_cache: ['none', 'sqlite']
         use-phar: [false, true]
         os: ['ubuntu-22.04', 'macos-latest', 'windows-latest']
@@ -107,19 +108,20 @@ jobs:
           - os: windows-latest
             test-package: db-command
             
-          # Limit MariaDB runs to php: 8.5, wp: trunk, os: ubuntu-22.04, object_cache: none, use-phar: false
+          # Globally exclude generated MariaDB + MySQL combinations
           - dbtype: mariadb
-            php: '7.2'
-          - dbtype: mariadb
-            wp: latest
-          - dbtype: mariadb
-            os: macos-latest
-          - dbtype: mariadb
-            os: windows-latest
-          - dbtype: mariadb
-            object_cache: sqlite
-          - dbtype: mariadb
-            use-phar: true
+            mysql: mysql-8.0
+
+        include:
+          # Include the single working MariaDB combination for all packages
+          - php: '8.5'
+            wp: trunk
+            dbtype: mariadb
+            mysql: mariadb-10.11
+            object_cache: none
+            use-phar: false
+            os: ubuntu-22.04
+
 
     uses: ./.github/workflows/reusable-testing.yml
     with:
@@ -130,4 +132,5 @@ jobs:
       object_cache: ${{ matrix.object_cache }}
       use-phar: ${{ matrix.use-phar }}
       os: ${{ matrix.os }}
+      mysql: ${{ matrix.mysql }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,6 +22,7 @@ jobs:
         dbtype: ['mysql', 'sqlite']
         object_cache: ['none', 'sqlite']
         use-phar: [false, true]
+        os: ['ubuntu-22.04', 'macos-latest', 'windows-latest']
         test-package:
           - wp-cli-bundle
           - wp-cli
@@ -83,6 +84,30 @@ jobs:
           - php: '7.2'
             wp: trunk
             
+          # Only run one macos combination: php: 8.5, wp: latest, dbtype: sqlite, object_cache: none, use-phar: false
+          - os: macos-latest
+            php: '7.2'
+          - os: macos-latest
+            wp: trunk
+          - os: macos-latest
+            dbtype: mysql
+          - os: macos-latest
+            object_cache: sqlite
+          - os: macos-latest
+            use-phar: true
+            
+          # Only run one windows combination: php: 8.5, wp: latest, dbtype: sqlite, object_cache: none, use-phar: false
+          - os: windows-latest
+            php: '7.2'
+          - os: windows-latest
+            wp: trunk
+          - os: windows-latest
+            dbtype: mysql
+          - os: windows-latest
+            object_cache: sqlite
+          - os: windows-latest
+            use-phar: true
+            
     uses: ./.github/workflows/reusable-testing.yml
     with:
       test-package: ${{ matrix.test-package }}
@@ -91,4 +116,5 @@ jobs:
       dbtype: ${{ matrix.dbtype }}
       object_cache: ${{ matrix.object_cache }}
       use-phar: ${{ matrix.use-phar }}
+      os: ${{ matrix.os }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         php: ['7.2', '8.5']
         wp: ['latest', 'trunk']
-        dbtype: ['mysql', 'sqlite']
+        dbtype: ['mysql', 'sqlite', 'mariadb']
         object_cache: ['none', 'sqlite']
         use-phar: [false, true]
         os: ['ubuntu-22.04', 'macos-latest', 'windows-latest']
@@ -101,7 +101,24 @@ jobs:
           - os: windows-latest
             object_cache: sqlite
 
+          # Skip Windows tests for db-command to to environment configuration issues with SQLite.
+          - os: windows-latest
+            test-package: db-command
             
+          # Limit MariaDB runs to php: 8.5, wp: trunk, os: ubuntu-22.04, object_cache: none, use-phar: false
+          - dbtype: mariadb
+            php: '7.2'
+          - dbtype: mariadb
+            wp: latest
+          - dbtype: mariadb
+            os: macos-latest
+          - dbtype: mariadb
+            os: windows-latest
+          - dbtype: mariadb
+            object_cache: sqlite
+          - dbtype: mariadb
+            use-phar: true
+
     uses: ./.github/workflows/reusable-testing.yml
     with:
       test-package: ${{ matrix.test-package }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -103,6 +103,23 @@ jobs:
             dbtype: mysql
           - os: windows-latest
             object_cache: sqlite
+
+        include:
+          # Explicitly add back the single combinations for macos and windows to run without phar, overriding global exclusions.
+          - os: macos-latest
+            php: '8.5'
+            test-package: wp-cli-bundle
+            wp: trunk
+            dbtype: sqlite
+            object_cache: none
+            use-phar: false
+          - os: windows-latest
+            php: '8.5'
+            test-package: wp-cli-bundle
+            wp: trunk
+            dbtype: sqlite
+            object_cache: none
+            use-phar: false
             
     uses: ./.github/workflows/reusable-testing.yml
     with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,6 @@ jobs:
         php: ['7.2', '8.5']
         wp: ['latest', 'trunk']
         dbtype: ['mysql', 'sqlite', 'mariadb']
-        mysql: ['mysql-8.0']
         object_cache: ['none', 'sqlite']
         use-phar: [false, true]
         os: ['ubuntu-22.04', 'macos-latest', 'windows-latest']
@@ -108,19 +107,20 @@ jobs:
           - os: windows-latest
             test-package: db-command
             
-          # Globally exclude generated MariaDB + MySQL combinations
+          # Limit MariaDB runs to php: 8.5, wp: trunk, os: ubuntu-22.04, object_cache: none, use-phar: false
           - dbtype: mariadb
-            mysql: mysql-8.0
+            php: '7.2'
+          - dbtype: mariadb
+            wp: latest
+          - dbtype: mariadb
+            os: macos-latest
+          - dbtype: mariadb
+            os: windows-latest
+          - dbtype: mariadb
+            object_cache: sqlite
+          - dbtype: mariadb
+            use-phar: true
 
-        include:
-          # Include the single working MariaDB combination for all packages
-          - php: '8.5'
-            wp: trunk
-            dbtype: mariadb
-            mysql: mariadb-10.11
-            object_cache: none
-            use-phar: false
-            os: ubuntu-22.04
 
 
     uses: ./.github/workflows/reusable-testing.yml
@@ -132,5 +132,5 @@ jobs:
       object_cache: ${{ matrix.object_cache }}
       use-phar: ${{ matrix.use-phar }}
       os: ${{ matrix.os }}
-      mysql: ${{ matrix.mysql }}
+      mysql: ${{ matrix.dbtype == 'mariadb' && 'mariadb-10.11' || 'mysql-8.0' }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -76,6 +76,8 @@ jobs:
             wp: trunk
           - use-phar: false
             wp: latest
+          - use-phar: true
+            php: '7.2'
             
           # Limit ancient php on trunk
           - php: '7.2'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -84,29 +84,25 @@ jobs:
           - php: '7.2'
             wp: trunk
             
-          # Only run one macos combination: php: 8.5, wp: latest, dbtype: sqlite, object_cache: none, use-phar: true
+          # Only run one macos combination: php: 8.5, wp: trunk, dbtype: sqlite, object_cache: none, use-phar: false
           - os: macos-latest
             php: '7.2'
           - os: macos-latest
-            wp: trunk
+            wp: latest
           - os: macos-latest
             dbtype: mysql
           - os: macos-latest
             object_cache: sqlite
-          - os: macos-latest
-            use-phar: false
             
-          # Only run one windows combination: php: 8.5, wp: latest, dbtype: sqlite, object_cache: none, use-phar: true
+          # Only run one windows combination: php: 8.5, wp: trunk, dbtype: sqlite, object_cache: none, use-phar: false
           - os: windows-latest
             php: '7.2'
           - os: windows-latest
-            wp: trunk
+            wp: latest
           - os: windows-latest
             dbtype: mysql
           - os: windows-latest
             object_cache: sqlite
-          - os: windows-latest
-            use-phar: false
             
     uses: ./.github/workflows/reusable-testing.yml
     with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -84,7 +84,7 @@ jobs:
           - php: '7.2'
             wp: trunk
             
-          # Only run one macos combination: php: 8.5, wp: latest, dbtype: sqlite, object_cache: none, use-phar: false
+          # Only run one macos combination: php: 8.5, wp: latest, dbtype: sqlite, object_cache: none, use-phar: true
           - os: macos-latest
             php: '7.2'
           - os: macos-latest
@@ -94,9 +94,9 @@ jobs:
           - os: macos-latest
             object_cache: sqlite
           - os: macos-latest
-            use-phar: true
+            use-phar: false
             
-          # Only run one windows combination: php: 8.5, wp: latest, dbtype: sqlite, object_cache: none, use-phar: false
+          # Only run one windows combination: php: 8.5, wp: latest, dbtype: sqlite, object_cache: none, use-phar: true
           - os: windows-latest
             php: '7.2'
           - os: windows-latest
@@ -106,7 +106,7 @@ jobs:
           - os: windows-latest
             object_cache: sqlite
           - os: windows-latest
-            use-phar: true
+            use-phar: false
             
     uses: ./.github/workflows/reusable-testing.yml
     with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -60,9 +60,6 @@ jobs:
           - dbtype: mysql
             object_cache: sqlite
             
-          # SQLite runs only on WP latest and PHP 8.5
-          - dbtype: sqlite
-            wp: trunk
           - dbtype: sqlite
             php: '7.2'
             
@@ -104,22 +101,6 @@ jobs:
           - os: windows-latest
             object_cache: sqlite
 
-        include:
-          # Explicitly add back the single combinations for macos and windows to run without phar, overriding global exclusions.
-          - os: macos-latest
-            php: '8.5'
-            test-package: wp-cli-bundle
-            wp: trunk
-            dbtype: sqlite
-            object_cache: none
-            use-phar: false
-          - os: windows-latest
-            php: '8.5'
-            test-package: wp-cli-bundle
-            wp: trunk
-            dbtype: sqlite
-            object_cache: none
-            use-phar: false
             
     uses: ./.github/workflows/reusable-testing.yml
     with:

--- a/bin/test-phar
+++ b/bin/test-phar
@@ -75,9 +75,9 @@ for RELEASE in $RELEASES; do
 
 	# Download binary and verify MD5 checksum.
 	BIN_FOLDER="$(mktemp -d)"
-	wget -O "${BIN_FOLDER}/wp-cli.phar.md5" "$MD5_URL"
+	curl -sLo "${BIN_FOLDER}/wp-cli.phar.md5" "$MD5_URL"
 	TARGET_MD5=$(cat "${BIN_FOLDER}/wp-cli.phar.md5")
-	wget -O "${BIN_FOLDER}/wp-cli.phar" "$PHAR_URL"
+	curl -sLo "${BIN_FOLDER}/wp-cli.phar" "$PHAR_URL"
 	if hash md5sum 2>/dev/null; then
 		DOWNLOAD_MD5=$(md5sum "${BIN_FOLDER}/wp-cli.phar" | cut -d ' ' -f 1)
 	else

--- a/bin/test-source
+++ b/bin/test-source
@@ -20,6 +20,10 @@ if [ -z "$BUILD_DIR" ]; then
 	export BUILD_DIR="${GITHUB_WORKSPACE:-$(pwd)}"
 fi
 
+if [[ "$OS" == "Windows_NT" ]]; then
+	export BUILD_DIR=$(cygpath -w "$BUILD_DIR")
+fi
+
 if [ -z "$TEST_PACKAGE" -o "$TEST_PACKAGE" == "none" ]; then
 	echo "Skipping feature tests completely."
 	exit 0
@@ -43,13 +47,18 @@ for REPO in $REPOS; do
 
 	echo "Testing package $REPO..."
 
-	BEHAT_TAGS=$(BEHAT_FEATURES_FOLDER=${BUILD_DIR}/vendor/${REPO}/features php ${BUILD_DIR}/vendor/wp-cli/wp-cli-tests/utils/behat-tags.php)
+	FEATURES_FOLDER="${BUILD_DIR}/vendor/${REPO}/features"
+	if [[ "$OS" == "Windows_NT" ]]; then
+		FEATURES_FOLDER=$(cygpath -w "$FEATURES_FOLDER")
+	fi
+
+	BEHAT_TAGS=$(BEHAT_FEATURES_FOLDER="$FEATURES_FOLDER" php "${BUILD_DIR}/vendor/wp-cli/wp-cli-tests/utils/behat-tags.php")
 	echo "Behat Tags: $BEHAT_TAGS"
 
 	set +e
-	"${BUILD_DIR}/vendor/bin/behat" --format progress $BEHAT_TAGS --strict  --suite $REPO
+	"${BUILD_DIR}/vendor/bin/behat" --format progress $BEHAT_TAGS --strict --suite $REPO
 	if [ $? -ne 0 ]; then
-		"${BUILD_DIR}/vendor/bin/behat" --format progress $BEHAT_TAGS --strict  --suite $REPO --rerun
+		"${BUILD_DIR}/vendor/bin/behat" --format progress $BEHAT_TAGS --strict --suite $REPO --rerun
 		if [ $? -ne 0 ]; then
 			FAILED_PACKAGES="$FAILED_PACKAGES ${RELEASE}:${REPO}"
 		fi

--- a/bin/test-source
+++ b/bin/test-source
@@ -20,10 +20,6 @@ if [ -z "$BUILD_DIR" ]; then
 	export BUILD_DIR="${GITHUB_WORKSPACE:-$(pwd)}"
 fi
 
-if [[ "$OS" == "Windows_NT" ]]; then
-	export BUILD_DIR=$(cygpath -w "$BUILD_DIR")
-fi
-
 if [ -z "$TEST_PACKAGE" -o "$TEST_PACKAGE" == "none" ]; then
 	echo "Skipping feature tests completely."
 	exit 0
@@ -48,9 +44,6 @@ for REPO in $REPOS; do
 	echo "Testing package $REPO..."
 
 	FEATURES_FOLDER="${BUILD_DIR}/vendor/${REPO}/features"
-	if [[ "$OS" == "Windows_NT" ]]; then
-		FEATURES_FOLDER=$(cygpath -w "$FEATURES_FOLDER")
-	fi
 
 	BEHAT_TAGS=$(BEHAT_FEATURES_FOLDER="$FEATURES_FOLDER" php "${BUILD_DIR}/vendor/wp-cli/wp-cli-tests/utils/behat-tags.php")
 	echo "Behat Tags: $BEHAT_TAGS"


### PR DESCRIPTION
Skips db-command + Windows + SQLite for now due to environment issues I couldn't figure out yet. But it's tested in the db-command repo anyway.

Also adds MariaDB to the matrix.

Fixes https://github.com/wp-cli/wp-cli-tests/issues/155