### PR TITLE
Cross the Phar and WordPress dimensions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -82,11 +82,24 @@ jobs:
           - php: '7.4'
             object_cache: sqlite
             
-          # Phar usage match defaults 
-          - use-phar: true
-            wp: trunk
-          - use-phar: false
+          # Phar and source are separate dimensions, not aliases for a WP
+          # version. Previously `use-phar: true` was excluded on trunk and
+          # `use-phar: false` on latest, which made the two fully determined by
+          # each other: the Phar was only ever tested against WP latest and
+          # source only against trunk, so source-on-latest — the ordinary local
+          # setup — went untested entirely.
+          #
+          # Cross them instead, dropping only the combinations that add no
+          # signal, which keeps the run under the 256-job matrix cap. What this
+          # buys is source against WP latest, and the Phar against trunk as an
+          # early warning that a WP change has broken the released binary.
+          # Neither of those runs with continue-on-error, so both can fail the
+          # build.
+          - php: '7.4'
             wp: latest
+            use-phar: false
+          - dbtype: sqlite
+            use-phar: false
             
           # Limit ancient php on trunk
           - php: '7.4'


### PR DESCRIPTION
Follow-up to #69, which is merged. This branch was restarted from `main` and carries one commit.

## The gap

Two exclusions in `testing.yml` removed `use-phar: true` on trunk and `use-phar: false` on latest:

```yaml
- use-phar: true
  wp: trunk
- use-phar: false
  wp: latest
```

Together they made each dimension fully determined by the other. `use-phar` was not really a matrix dimension at all, it was an alias for the WordPress version: the Phar was only ever tested against WP latest, and source only against trunk.

That left two combinations untested. One of them is source against WP latest — the ordinary local setup, and arguably the most important combination in the file.

## The fix, and why it is not simply "remove the exclusions"

Removing both would enable the full cross product, which comes to 310 jobs and exceeds GitHub's cap of 256 matrix jobs per workflow run.

So the dimensions are crossed and only the combinations that add no signal are dropped:

| | combinations per package | total jobs |
| --- | --- | --- |
| before | 5 | 155 |
| full cross product | 10 | 310 — over the cap |
| this change | 7 | 217 |

All four `(wp, use-phar)` pairs are covered now. What it buys:

- **source against WP latest** — previously untested entirely.
- **the Phar against trunk** — early warning that a WordPress change has broken the released binary.

Neither of the two new legs is covered by the `continue-on-error` condition, which fires on `dbtype: sqlite` or `object_cache: sqlite`. Both can therefore fail the build, rather than adding to the pile of jobs that run without producing a gating signal.

## Note on the remaining headroom

217 of 256 leaves room for roughly five more packages before the cap is hit, at which point either a dimension has to give or the matrix has to be split across jobs. Worth knowing before the next package is added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jy4dmjymj9VmoTBaqrV4iX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded functional test coverage across Phar and source execution modes and multiple WordPress versions.
  * Streamlined the test matrix to reduce redundant combinations while retaining key compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->