### PR TITLE
Drop the environment matrix from the bundle integration tests

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -31,9 +31,9 @@ jobs:
   run-test:
     name: WP ${{ inputs.wp }} | PHP ${{ inputs.php }} | ${{ inputs.dbtype == 'sqlite' && 'SQLite' || inputs.dbtype == 'mysql' && 'MySQL' || 'MariaDB' }}${{ inputs.use-phar && ' (Phar)' || '' }}${{ inputs.object_cache == 'sqlite' && ' (Obj Cache)' || '' }}
     runs-on: ubuntu-22.04
-    # Every leg gates now. The condition previously exempted the SQLite and object
-    # cache legs, which is 62 of the 217 jobs — they consumed runner time without
-    # ever being able to fail the build. Those legs are gone rather than silenced.
+    # In this repository’s current matrix, every leg gates. The `continue-on-error`
+    # condition is retained so callers can still run optional SQLite/object-cache
+    # legs without reshaping the workflow, if needed.
     continue-on-error: ${{ inputs.dbtype == 'sqlite' || inputs.object_cache == 'sqlite' }}
     timeout-minutes: 90
 

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -12,12 +12,17 @@ on:
       wp:
         type: string
         required: true
+      # Retained as optional inputs rather than removed, so a database or object
+      # cache leg can be reinstated without reshaping the workflow. The matrix no
+      # longer varies them: storage backends are covered per-package.
       dbtype:
         type: string
-        required: true
+        required: false
+        default: 'mysql'
       object_cache:
         type: string
-        required: true
+        required: false
+        default: 'none'
       use-phar:
         type: boolean
         required: true
@@ -26,6 +31,9 @@ jobs:
   run-test:
     name: WP ${{ inputs.wp }} | PHP ${{ inputs.php }} | ${{ inputs.dbtype == 'sqlite' && 'SQLite' || inputs.dbtype == 'mysql' && 'MySQL' || 'MariaDB' }}${{ inputs.use-phar && ' (Phar)' || '' }}${{ inputs.object_cache == 'sqlite' && ' (Obj Cache)' || '' }}
     runs-on: ubuntu-22.04
+    # Every leg gates now. The condition previously exempted the SQLite and object
+    # cache legs, which is 62 of the 217 jobs — they consumed runner time without
+    # ever being able to fail the build. Those legs are gone rather than silenced.
     continue-on-error: ${{ inputs.dbtype == 'sqlite' || inputs.object_cache == 'sqlite' }}
     timeout-minutes: 90
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,8 +28,6 @@ jobs:
       matrix:
         php: ['7.4', '8.5']
         wp: ['latest', 'trunk']
-        dbtype: ['mysql', 'sqlite']
-        object_cache: ['none', 'sqlite']
         use-phar: [false, true]
         test-package:
           - wp-cli-bundle
@@ -64,53 +62,19 @@ jobs:
           - super-admin-command
           - widget-command
         exclude:
-          # Object cache runs only on sqlite dbtype
-          - dbtype: mysql
-            object_cache: sqlite
-            
-          # SQLite runs only on WP latest and PHP 8.5
-          - dbtype: sqlite
-            wp: trunk
-          - dbtype: sqlite
-            php: '7.4'
-            
-          # Object cache runs only with WP latest
-          - object_cache: sqlite
-            wp: trunk
-            
-          # A1: object_cache=sqlite only on PHP 8.5
+          # PHP 7.4 is covered per-package across the full version matrix. Keep a
+          # single bundle-integration leg for it — enough to catch a package
+          # raising its PHP requirement and breaking `composer install` for the
+          # bundle, which is the one failure only this repository sees.
           - php: '7.4'
-            object_cache: sqlite
-            
-          # Phar and source are separate dimensions, not aliases for a WP
-          # version. Previously `use-phar: true` was excluded on trunk and
-          # `use-phar: false` on latest, which made the two fully determined by
-          # each other: the Phar was only ever tested against WP latest and
-          # source only against trunk, so source-on-latest — the ordinary local
-          # setup — went untested entirely.
-          #
-          # Cross them instead, dropping only the combinations that add no
-          # signal, which keeps the run under the 256-job matrix cap. What this
-          # buys is source against WP latest, and the Phar against trunk as an
-          # early warning that a WP change has broken the released binary.
-          # Neither of those runs with continue-on-error, so both can fail the
-          # build.
+            wp: trunk
           - php: '7.4'
-            wp: latest
             use-phar: false
-          - dbtype: sqlite
-            use-phar: false
-            
-          # Limit ancient php on trunk
-          - php: '7.4'
-            wp: trunk
-            
+
     uses: ./.github/workflows/reusable-testing.yml
     with:
       test-package: ${{ matrix.test-package }}
       php: ${{ matrix.php }}
       wp: ${{ matrix.wp }}
-      dbtype: ${{ matrix.dbtype }}
-      object_cache: ${{ matrix.object_cache }}
       use-phar: ${{ matrix.use-phar }}
 


### PR DESCRIPTION
Stacked on #70 so the two do not collide in the same `exclude` block. Once #70 merges this collapses to a single commit; until then its change shows here too.

## What only this repository tests

`bin/test-phar` downloads the built Phar and runs each package's features against that binary. `bin/test-source` runs them from `vendor/${REPO}/features` with `--suite $REPO` inside a full bundle install. So two things are unique here:

- **the Phar** — no package repository ever builds or exercises it;
- **cross-package integration** — a package's features running with every bundled package installed at `dev-main`, rather than in isolation.

Everything else this varied is already covered per-package, at much higher resolution:

| dimension | package repository | here, before |
| --- | --- | --- |
| PHP | 7.2 – 8.5 and nightly | 7.4, 8.5 |
| WordPress | 4.9, 6.9, latest, trunk | latest, trunk |
| database | MySQL 5.6 – 8.4, MariaDB, SQLite | MySQL 8.0, SQLite |
| object cache | yes | yes |
| **Phar** | **never** | **yes** |
| **bundle integration** | **never** | **yes** |

## The change

`dbtype` and `object_cache` stop being matrix dimensions. What remains is PHP, WordPress, and Phar-versus-source.

## Gating coverage is unchanged

Every leg this removes was already exempted by `continue-on-error: ${{ inputs.dbtype == 'sqlite' || inputs.object_cache == 'sqlite' }}`. The set of jobs that can actually fail the build is the same five per package as after #70:

```
php 7.4  latest  phar
php 8.5  latest  source
php 8.5  latest  phar
php 8.5  trunk   source
php 8.5  trunk   phar
```

| | jobs | of which can fail the build |
| --- | --- | --- |
| after #70 | 217 | 155 |
| after this | **155** | **155** |

The 62 jobs that go away spent runner time without ever being able to report a failure.

## Two deliberate calls

**PHP 7.4 keeps one leg.** It is covered per-package across the full matrix, but a package raising its PHP requirement and breaking `composer install` for the bundle is a failure only this repository sees. One leg catches that; four were not buying anything more.

**The inputs stay on the reusable workflow**, defaulted to `mysql` and `none` rather than deleted, so a storage backend leg can be reinstated without reshaping the workflow.

## Headroom

At 5 combinations per package, the 256-job matrix cap is reached at about 51 packages instead of 36 — roughly twenty more packages of room rather than five.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jy4dmjymj9VmoTBaqrV4iX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified automated testing configurations by removing unnecessary database and object-cache variations.
  * Added sensible defaults for database and object-cache settings when running reusable tests.
  * Updated test coverage rules for PHP 7.4, non-trunk WordPress versions, and bundle integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->